### PR TITLE
Add IAM Policy for API Reads

### DIFF
--- a/api_policies.tf
+++ b/api_policies.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_policy" "inventory-api-read-policy" {
+  name        = "InventoryAPIRead"
+  description = "Policy allowing read access to the Inventory API"
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "execute-api:Invoke"
+            ],
+            "Resource": [
+                "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*/*/GET/*"
+            ]
+        }
+    ]
+}
+POLICY
+}


### PR DESCRIPTION
The wildcards for api id and stage are less than optimal.  That should
be parameterized somehow.  I'm not sure how to query that information
from terraform, and neither is guarenteed to exist when the terraform
run happens.